### PR TITLE
Changed to LLVM build to blob storage

### DIFF
--- a/devops/CI.yml
+++ b/devops/CI.yml
@@ -41,11 +41,6 @@ jobs:
       sudo snap install cmake --classic
     displayName: 'Dependencies'
 
-  - script: echo $AZURE_DEVOPS_CLI_PAT | az devops login --organization https://dev.azure.com/msr-gryffindor
-    env:
-      AZURE_DEVOPS_CLI_PAT: $(System.AccessToken)
-    displayName: 'Login Azure DevOps Extension'
-
   - script: ./apply-guest-patches.sh
     displayName: Patch externals
     workingDirectory: external

--- a/devops/LLVM.yml
+++ b/devops/LLVM.yml
@@ -31,8 +31,8 @@ jobs:
       curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
     displayName: 'Install Build Dependencies'
   - script: |
-      git apply ../patches/llvm-clang.patch
       git apply ../patches/llvm-libcxx.patch
+      git apply ../patches/llvm-clang.patch
     displayName: Patch LLVM
     workingDirectory: external/llvm-project
   - task: CMake@1
@@ -47,15 +47,15 @@ jobs:
     displayName: 'Compile LLVM & MLIR'
   - script: |
       set -eo pipefail
-      rm -f $(Build.ArtifactStagingDirectory)/$(PKG_NAME).tar.gz
-      tar zcf $(Build.ArtifactStagingDirectory)/$(PKG_NAME).tar.gz build/install
-      md5sum $(Build.ArtifactStagingDirectory)/$(PKG_NAME).tar.gz | awk '{print $1}' > $(Build.ArtifactStagingDirectory)/$(PKG_NAME).tar.gz.md5
-    displayName: 'Create package'
-  - task: UniversalPackages@0
-    displayName: Universal Publish
-    inputs:
-      command: publish
-      publishDirectory: '$(Build.ArtifactStagingDirectory)'
-      vstsFeedPublish: 'Monza/LLVMBuild'
-      vstsFeedPackagePublish: 'monza-llvm'
-      packagePublishDescription: 'Full LLVM build for Monza'
+      cd ../external/llvm-project
+      ACTUAL_HASH="`git rev-parse HEAD`-`md5sum ../patches/llvm-libcxx.patch | awk '{print $1}'`-`md5sum ../patches/llvm-clang.patch | awk '{print $1}'`"
+      FINAL_PACKAGE_NAME="$(PKG_NAME)-$ACTUAL_HASH.tar.gz"
+      echo "Package name is: $FINAL_PACKAGE_NAME"
+      cd ../../build
+      rm -f $FINAL_PACKAGE_NAME
+      tar zcf $FINAL_PACKAGE_NAME install
+      md5sum $FINAL_PACKAGE_NAME | awk '{print $1}' > $FINAL_PACKAGE_NAME.md5
+      az storage blob upload --overwrite --container-name llvmbuild --file $FINAL_PACKAGE_NAME --name $FINAL_PACKAGE_NAME --account-name verona --sas-token "$(BLOB_SAS_TOKEN)"
+      az storage blob upload --overwrite --container-name llvmbuild --file $FINAL_PACKAGE_NAME.md5 --name $FINAL_PACKAGE_NAME.md5 --account-name verona --sas-token "$(BLOB_SAS_TOKEN)"
+    displayName: 'Create and upload package'
+    workingDirectory: build

--- a/devops/LLVM.yml
+++ b/devops/LLVM.yml
@@ -1,5 +1,7 @@
 trigger: none
 
+pr: none
+
 jobs:
 ############################################## Linux Builds
 - job:

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -21,6 +21,22 @@ if (MONZA_DOWNLOAD_LLVM)
   )
   string(STRIP ${LLVM_PACKAGE_GIT_VERSION} LLVM_PACKAGE_GIT_VERSION)
   message (STATUS "Detected GIT commit: ${LLVM_PACKAGE_GIT_VERSION}")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E md5sum llvm-libcxx.patch
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/patches"
+    OUTPUT_VARIABLE LLVM_LIBCXX_HASH_OUTPUT
+  )
+  string(FIND ${LLVM_LIBCXX_HASH_OUTPUT} " " HASH_SPACE_POS)
+  string(SUBSTRING ${LLVM_LIBCXX_HASH_OUTPUT} 0 ${HASH_SPACE_POS} LLVM_LIBCXX_HASH)
+  message (STATUS "Detected libcxx patch: ${LLVM_LIBCXX_HASH}")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E md5sum llvm-clang.patch
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/patches"
+    OUTPUT_VARIABLE LLVM_CLANG_HASH_OUTPUT
+  )
+  string(FIND ${LLVM_CLANG_HASH_OUTPUT} " " HASH_SPACE_POS)
+  string(SUBSTRING ${LLVM_CLANG_HASH_OUTPUT} 0 ${HASH_SPACE_POS} LLVM_CLANG_HASH)
+  message (STATUS "Detected clang patch: ${LLVM_CLANG_HASH}")
 
   string(TOLOWER ${CMAKE_SYSTEM_NAME} PLATFORM)
   # Need loop to download all types for possible configurations
@@ -38,33 +54,28 @@ if (MONZA_DOWNLOAD_LLVM)
 
 
   # Setup LLVM download (+MD5 string)
-  execute_process(
-    COMMAND az artifacts universal download --organization https://dev.azure.com/msr-gryffindor --scope project --project Monza --feed LLVMBuild --name monza-llvm --version ${MONZA_DOWNLOAD_LLVM} --path .
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    ERROR_VARIABLE AZ_ARTIFACTS_ERROR
-  )
   if (NOT ${AZ_ARTIFACTS_ERROR} STREQUAL "")
     message(FATAL_ERROR ${AZ_ARTIFACTS_ERROR})
   endif()
-  set(LLVM_URL ${CMAKE_BINARY_DIR})
-  set(PKG_NAME monza-llvm-install-x86_64-${PLATFORM}-${LLVM_BUILD_TYPE})
-  set(MD5_NAME ${PKG_NAME}.tar.gz.md5)
-  # file(DOWNLOAD "${LLVM_URL}/${MD5_NAME}" ${CMAKE_BINARY_DIR}/${MD5_NAME} STATUS MD5_DOWNLOAD_STATUS)
-  # list(GET MD5_DOWNLOAD_STATUS 0 MD5_DOWNLOAD_STATUS_CODE)
-  # if (NOT (${MD5_DOWNLOAD_STATUS_CODE} EQUAL 0))
-  #   list(GET MD5_DOWNLOAD_STATUS 1 ERROR_MESSAGE)
-  #  message(FATAL_ERROR "Failed to download md5 hash: ${ERROR_MESSAGE}")
-  # endif ()
+  set(LLVM_URL https://verona.blob.core.windows.net/llvmbuild)
+  set(PKG_NAME monza-llvm-install-x86_64-${PLATFORM}-${LLVM_BUILD_TYPE}-${LLVM_PACKAGE_GIT_VERSION}-${LLVM_LIBCXX_HASH}-${LLVM_CLANG_HASH}.tar.gz)
+  set(MD5_NAME ${PKG_NAME}.md5)
+  file(DOWNLOAD "${LLVM_URL}/${MD5_NAME}" ${CMAKE_BINARY_DIR}/${MD5_NAME} STATUS MD5_DOWNLOAD_STATUS)
+  list(GET MD5_DOWNLOAD_STATUS 0 MD5_DOWNLOAD_STATUS_CODE)
+  if (NOT (${MD5_DOWNLOAD_STATUS_CODE} EQUAL 0))
+    list(GET MD5_DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+    message(FATAL_ERROR "Failed to download md5 hash: ${ERROR_MESSAGE}")
+  endif ()
   file(STRINGS ${CMAKE_BINARY_DIR}/${MD5_NAME} LLVM_MD5_SUM REGEX [0-9a-f]+)
   string(STRIP ${LLVM_MD5_SUM} LLVM_MD5_SUM)
 
   ExternalProject_Add(llvm
-    URL ${LLVM_URL}/${PKG_NAME}.tar.gz
+    URL ${LLVM_URL}/${PKG_NAME}
     URL_MD5 ${LLVM_MD5_SUM}
     DOWNLOAD_NO_PROGRESS NOT ${VERBOSE_LLVM_DOWNLOAD}
     CONFIGURE_COMMAND ""
     PREFIX llvm-${LLVM_BUILD_TYPE}
-    SOURCE_DIR ${LLVM_INSTALL}
+    SOURCE_DIR ${LLVM_INSTALL}/install
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     TEST_COMMAND ""


### PR DESCRIPTION
This should enable forks to be processed in PRs.
Uses the Verona blob storage and upload/download mechanism.
File tagged with LLVM commit, but also the hash of the two patch files.