### PR TITLE
Re-enabled core sleeping when there is no Verona work

### DIFF
--- a/guest-verona-rt/arch/x86_64/cores.asm
+++ b/guest-verona-rt/arch/x86_64/cores.asm
@@ -33,7 +33,7 @@ acquire_semaphore:
     mov rcx, [rdi]
     test rcx, rcx
     jnz .end_suspend
-    ;hlt
+    hlt
     ; Marker for the interrupt handler to detect if hlt has been executed already.
     ; If this instruction pointer is reached, then we finished with the atomic block and can continue as normal.
     ; If not, then reset to .loop_suspend to ensure atomicity.


### PR DESCRIPTION
At some point in the past, I disabled sleeping in favor of polling to avoid needing the IPIs to wake up the threads.
The IPI mechanism works well on QEMU so I am re-enabling sleeping.