### PR TITLE
Experimental Windows host

### DIFF
--- a/app-framework/include/guest/ringbuffer_guest.h
+++ b/app-framework/include/guest/ringbuffer_guest.h
@@ -5,8 +5,8 @@
 
 #include <address.h>
 #include <ds/ring_buffer.h>
-#include <pagetable.h>
 #include <ringbuffer_initializer.h>
+#include <shared.h>
 #include <snmalloc.h>
 
 extern int app_main(

--- a/app-framework/include/host/enclave_platform.h
+++ b/app-framework/include/host/enclave_platform.h
@@ -342,7 +342,7 @@ namespace monza::host
       else
       {
         throw std::runtime_error(
-          "No enough enclave shared memoy for initialization arguments.");
+          "No enough enclave shared memory for initialization arguments.");
       }
     }
 

--- a/app-framework/include/host/enclave_platform.h
+++ b/app-framework/include/host/enclave_platform.h
@@ -300,7 +300,7 @@ namespace monza::host
       else
       {
         throw std::runtime_error(
-          "No enough enclave shared memory for allocation.");
+          "Not enough enclave shared memory for allocation.");
       }
     }
 

--- a/app-framework/include/host/enclave_platform.h
+++ b/app-framework/include/host/enclave_platform.h
@@ -341,7 +341,6 @@ namespace monza::host
       }
       else
       {
-        cleanup();
         throw std::runtime_error(
           "No enough enclave shared memoy for initialization arguments.");
       }
@@ -356,10 +355,6 @@ namespace monza::host
       {
         join();
       }
-
-      free(shmem_base);
-
-      cleanup();
     }
 
   public:

--- a/app-framework/include/host/enclave_platform.h
+++ b/app-framework/include/host/enclave_platform.h
@@ -26,6 +26,10 @@
 #  include <unistd.h>
 #endif
 
+#ifdef MONZA_HOST_SUPPORTS_HCS
+#  include <hcs_enclave.h>
+#endif
+
 namespace monza::host
 {
   template<typename T>
@@ -44,7 +48,8 @@ namespace monza::host
 
   enum class EnclaveType
   {
-    QEMU
+    QEMU,
+    HCS
   };
 
   template<typename InitializerTuple>
@@ -116,8 +121,8 @@ namespace monza::host
   template<typename InitializerTuple>
   class QemuEnclavePlatform : public EnclavePlatform<InitializerTuple>
   {
-    static constexpr size_t QEMU_SHMEM_SIZE = 64 * 1024 * 1024;
-    static constexpr size_t QEMU_SHMEM_START = (1UL << 40) - QEMU_SHMEM_SIZE;
+    static constexpr size_t SHMEM_SIZE = 64 * 1024 * 1024;
+    static constexpr size_t SHMEM_START = (1ULL << 40) - SHMEM_SIZE;
 
     static inline std::default_random_engine id_generator;
     static inline std::uniform_int_distribution<uint64_t> id_distribution;
@@ -160,12 +165,12 @@ namespace monza::host
       auto cores_argument = cores_argument_builder.str();
       std::stringstream shmem_file_argument_builder;
       shmem_file_argument_builder
-        << "memory-backend-file,id=shmem,share=on,size=" << QEMU_SHMEM_SIZE
+        << "memory-backend-file,id=shmem,share=on,size=" << SHMEM_SIZE
         << ",mem-path=/dev/shm/" << shmem_file;
       auto shmem_file_argument = shmem_file_argument_builder.str();
       std::stringstream shmem_device_argument_builder;
       shmem_device_argument_builder << "pc-dimm,memdev=shmem,addr="
-                                    << QEMU_SHMEM_START;
+                                    << SHMEM_START;
       auto shmem_device_argument = shmem_device_argument_builder.str();
       std::stringstream monitor_file_argument_builder;
       monitor_file_argument_builder << "unix:" << monitor_file
@@ -199,12 +204,7 @@ namespace monza::host
           "Failed to map enclave shared memory to host.");
       }
       shmem_base = static_cast<uint8_t*>(mmap(
-        0,
-        QEMU_SHMEM_SIZE,
-        PROT_READ | PROT_WRITE,
-        MAP_SHARED,
-        shmem_file_id,
-        0));
+        0, SHMEM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, shmem_file_id, 0));
       if (shmem_base == MAP_FAILED)
       {
         cleanup();
@@ -214,7 +214,7 @@ namespace monza::host
       shmem_offset = 0;
 
       // Reserve space for InitializerTuple.
-      if (QEMU_SHMEM_SIZE > sizeof(InitializerTuple))
+      if (SHMEM_SIZE > sizeof(InitializerTuple))
       {
         shmem_offset += sizeof(InitializerTuple);
       }
@@ -249,7 +249,7 @@ namespace monza::host
         join();
       }
 
-      munmap(shmem_base, QEMU_SHMEM_SIZE);
+      munmap(shmem_base, SHMEM_SIZE);
 
       cleanup();
     }
@@ -288,12 +288,115 @@ namespace monza::host
       if (
         aligned_shmem_offset >= shmem_offset &&
         aligned_shmem_offset + size > aligned_shmem_offset &&
-        aligned_shmem_offset + size < QEMU_SHMEM_SIZE)
+        aligned_shmem_offset + size < SHMEM_SIZE)
       {
         memset(shmem_base + aligned_shmem_offset, 0, size);
         auto result = std::make_pair(
           shmem_base + aligned_shmem_offset,
-          QEMU_SHMEM_START + aligned_shmem_offset);
+          SHMEM_START + aligned_shmem_offset);
+        shmem_offset = aligned_shmem_offset + size;
+        return result;
+      }
+      else
+      {
+        throw std::runtime_error(
+          "No enough enclave shared memory for allocation.");
+      }
+    }
+
+    friend class EnclavePlatform<InitializerTuple>;
+  };
+
+#endif
+
+#ifdef MONZA_HOST_SUPPORTS_HCS
+
+  template<typename InitializerTuple>
+  class HcsEnclavePlatform : public EnclavePlatform<InitializerTuple>
+  {
+    static constexpr size_t SHMEM_SIZE = 64 * 1024 * 1024;
+
+    std::unique_ptr<HCSEnclaveAbstract> instance;
+
+    size_t shmem_guest_base;
+    uint8_t* shmem_base;
+    size_t shmem_offset;
+
+    bool joined;
+
+  protected:
+    HcsEnclavePlatform(
+      EnclaveType type, const std::string& path, size_t num_threads)
+    : EnclavePlatform<InitializerTuple>(num_threads),
+      instance(HCSEnclaveAbstract::create(path, num_threads, SHMEM_SIZE)),
+      shmem_guest_base(instance->shared_memory_guest_base()),
+      shmem_base(instance->shared_memory().data()),
+      shmem_offset(0),
+      joined(false)
+    {
+      // Reserve space for InitializerTuple.
+      if (SHMEM_SIZE > sizeof(InitializerTuple))
+      {
+        shmem_offset += sizeof(InitializerTuple);
+      }
+      else
+      {
+        cleanup();
+        throw std::runtime_error(
+          "No enough enclave shared memoy for initialization arguments.");
+      }
+    }
+
+    void cleanup() {}
+
+  public:
+    ~HcsEnclavePlatform() override
+    {
+      if (!joined)
+      {
+        join();
+      }
+
+      free(shmem_base);
+
+      cleanup();
+    }
+
+  public:
+    void initialize(InitializerTuple initArgs) override
+    {
+      *reinterpret_cast<InitializerTuple*>(shmem_base) = initArgs;
+    }
+
+    void async_run() override
+    {
+      instance->async_run();
+    }
+
+    void join() override
+    {
+      if (!joined)
+      {
+        instance->join();
+      }
+      joined = true;
+    }
+
+  protected:
+    std::pair<void*, uintptr_t>
+    allocate_shared_inner(size_t size, size_t alignment) override
+    {
+      auto aligned_shmem_offset =
+        ((shmem_offset + alignment - 1) / alignment) * alignment;
+      if (
+        aligned_shmem_offset >= shmem_offset &&
+        aligned_shmem_offset + size > aligned_shmem_offset &&
+        aligned_shmem_offset + size < SHMEM_SIZE)
+      {
+        memset(shmem_base + aligned_shmem_offset, 0, size);
+        auto result = std::make_pair(
+          shmem_base + aligned_shmem_offset,
+          shmem_guest_base + aligned_shmem_offset);
         shmem_offset = aligned_shmem_offset + size;
         return result;
       }
@@ -327,6 +430,14 @@ namespace monza::host
         throw std::logic_error(
           "QEMU Monza enclaves are not supported in current build");
 #endif // MONZA_HOST_SUPPORTS_QEMU
+      case EnclaveType::HCS:
+#ifdef MONZA_HOST_SUPPORTS_HCS
+        return std::unique_ptr<EnclavePlatform<T>>(
+          new HcsEnclavePlatform<T>(type, path, num_threads));
+#else
+        throw std::logic_error(
+          "HCS Monza enclaves are not supported in current build");
+#endif // MONZA_HOST_SUPPORTS_HCS
     }
   }
 }

--- a/app-framework/include/host/hcs_enclave.h
+++ b/app-framework/include/host/hcs_enclave.h
@@ -1,0 +1,42 @@
+// Copyright Microsoft and Project Monza Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdlib>
+#include <memory>
+#include <span>
+#include <string>
+
+namespace monza::host
+{
+  class HCSEnclaveAbstract
+  {
+  protected:
+    std::string image_path;
+    size_t num_threads;
+    size_t shared_memory_size;
+
+    HCSEnclaveAbstract(
+      const std::string& image_path,
+      size_t num_threads,
+      size_t shared_memory_size)
+    : image_path(image_path),
+      num_threads(num_threads),
+      shared_memory_size(shared_memory_size)
+    {}
+
+  public:
+    virtual ~HCSEnclaveAbstract() {}
+
+    virtual size_t shared_memory_guest_base() = 0;
+    virtual std::span<uint8_t> shared_memory() = 0;
+    virtual void async_run() = 0;
+    virtual void join() = 0;
+
+    static std::unique_ptr<HCSEnclaveAbstract> create(
+      const std::string& image_path,
+      size_t num_threads,
+      size_t shared_memory_size);
+  };
+}

--- a/apps/example/host.cc
+++ b/apps/example/host.cc
@@ -16,17 +16,19 @@ int main(int argc, char** argv)
   {
     std::cout << "Usage: apps-example-host TYPE PATH_TO_GUEST_IMAGE."
               << std::endl;
+    exit(-1);
   }
   auto enclave_type = monza::host::EnclaveType::QEMU;
   if (std::string(argv[1]) == "HCS")
   {
     enclave_type = monza::host::EnclaveType::HCS;
   }
+  auto guest_path = std::string(argv[2]);
 
   try
   {
-    monza::host::RingbufferGuest guest(enclave_type, argv[2], 1);
-    std::cout << "Create guest instance using path " << argv[2] << std::endl;
+    monza::host::RingbufferGuest guest(enclave_type, guest_path, 1);
+    std::cout << "Create guest instance using path " << guest_path << std::endl;
     messaging::BufferProcessor bp("Host");
 
     // Set up handler for pong to be used while polling.

--- a/apps/example/host.cc
+++ b/apps/example/host.cc
@@ -10,31 +10,52 @@ const std::string TEST_MESSAGE = "Hello world!";
 
 bool success = false;
 
-int main()
+int main(int argc, char** argv)
 {
-  monza::host::RingbufferGuest guest(
-    monza::host::EnclaveType::QEMU, "qemu-apps-example-guest.img", 1);
-  messaging::BufferProcessor bp("Host");
-
-  // Set up handler for pong to be used while polling.
-  DISPATCHER_SET_MESSAGE_HANDLER(
-    bp, example::pong, [](const uint8_t* data, size_t size) {
-      auto [response] = ringbuffer::read_message<example::pong>(data, size);
-      std::cout << "Host received: " << response << std::endl;
-      success = true;
-    });
-
-  // Start guest.
-  guest.async_run();
-  // Write ping to guest.
-  RINGBUFFER_WRITE_MESSAGE(example::ping, guest.writer(), TEST_MESSAGE);
-  // Poll receive buffer until response received.
-  while (!success)
+  if (argc < 3)
   {
-    bp.read_all(guest.reader());
+    std::cout << "Usage: apps-example-host TYPE PATH_TO_GUEST_IMAGE."
+              << std::endl;
+  }
+  auto enclave_type = monza::host::EnclaveType::QEMU;
+  if (std::string(argv[1]) == "HCS")
+  {
+    enclave_type = monza::host::EnclaveType::HCS;
   }
 
-  // Clean terminate.
-  guest.join();
+  try
+  {
+    monza::host::RingbufferGuest guest(enclave_type, argv[2], 1);
+    std::cout << "Create guest instance using path " << argv[2] << std::endl;
+    messaging::BufferProcessor bp("Host");
+
+    // Set up handler for pong to be used while polling.
+    DISPATCHER_SET_MESSAGE_HANDLER(
+      bp, example::pong, [](const uint8_t* data, size_t size) {
+        auto [response] = ringbuffer::read_message<example::pong>(data, size);
+        std::cout << "Host received: " << response << std::endl;
+        success = true;
+      });
+
+    // Start guest.
+    std::cout << "Starting instance" << std::endl;
+    guest.async_run();
+    // Write ping to guest.
+    RINGBUFFER_WRITE_MESSAGE(example::ping, guest.writer(), TEST_MESSAGE);
+    // Poll receive buffer until response received.
+    while (!success)
+    {
+      bp.read_all(guest.reader());
+    }
+
+    // Clean terminate.
+    std::cout << "Waiting for instance" << std::endl;
+    guest.join();
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << e.what() << std::endl;
+    exit(-1);
+  }
   return 0;
 }

--- a/guest-verona-rt/arch/x86_64/cores_generic.cc
+++ b/guest-verona-rt/arch/x86_64/cores_generic.cc
@@ -12,6 +12,8 @@
 #include <snmalloc.h>
 #include <tls.h>
 
+extern "C" void triple_fault();
+
 // Globals accessed from assembly so avoid namespacing
 extern uint8_t* local_apic_mapping;
 uint8_t* local_apic_mapping = nullptr;
@@ -334,6 +336,7 @@ namespace monza
 
   /**
    * VMM-specific shutdown codes.
+   * Fallback to triple fault if the codes don't work.
    * Proper power-down requires complex code to manage ACPI in this file.
    */
   void shutdown_generic()
@@ -342,7 +345,7 @@ namespace monza
     out<uint8_t>(0xFE, 0x64);
     while (true)
     {
-      asm volatile("hlt");
+      triple_fault();
     }
   }
 }

--- a/guest-verona-rt/arch/x86_64/hv.cc
+++ b/guest-verona-rt/arch/x86_64/hv.cc
@@ -1,0 +1,383 @@
+// Copyright Microsoft and Project Monza Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <crt.h>
+#include <gdt.h>
+#include <heap.h>
+#include <hv.h>
+#include <hypervisor.h>
+#include <logging.h>
+#include <per_core_data.h>
+#include <shared_arch.h>
+#include <snmalloc.h>
+
+extern char __hv_hypercall_codepage_start;
+
+extern "C" void ap_reset();
+
+extern "C" uint8_t* local_apic_mapping;
+
+namespace monza
+{
+  // Ensure that this is in the data section, since the BSS might not be fully
+  // mapped at boot.
+  __attribute__((section(".data"))) static void* hv_call_target = nullptr;
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/tlfs
+   * Appendix B.
+   */
+  void print_hv_status(StatusCode status)
+  {
+    switch (status)
+    {
+      case HV_STATUS_SUCCESS:
+        LOG_MOD(INFO, HyperV) << "Success." << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_HYPERCALL_CODE:
+        LOG_MOD(INFO, HyperV) << "Invalid hypercall code." << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_ALIGNMENT:
+        LOG_MOD(INFO, HyperV)
+          << "A parameter has an invalid alignment." << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_PARAMETER:
+        LOG_MOD(INFO, HyperV)
+          << "An invalid parameter was specified." << LOG_ENDL;
+        break;
+      case HV_STATUS_ACCESS_DENIED:
+        LOG_MOD(INFO, HyperV) << "Access denied." << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_PARTITION_STATE:
+        LOG_MOD(INFO, HyperV)
+          << "The specified partition is not in the “active” state."
+          << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_PARTITION_ID:
+        LOG_MOD(INFO, HyperV)
+          << "The specified partition ID is invalid." << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_VP_INDEX:
+        LOG_MOD(INFO, HyperV)
+          << "The virtual processor specified by HV_VP_INDEX is invalid."
+          << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_PORT_ID:
+        LOG_MOD(INFO, HyperV) << "The port associated with the specified "
+                                 "connection has been deleted."
+                              << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_CONNECTION_ID:
+        LOG_MOD(INFO, HyperV)
+          << "The specified connection identifier is invalid." << LOG_ENDL;
+        break;
+      case HV_STATUS_INSUFFICIENT_BUFFERS:
+        LOG_MOD(INFO, HyperV)
+          << "Not enough message buffers supplied to send a message."
+          << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_VP_STATE:
+        LOG_MOD(INFO, HyperV)
+          << "A virtual processor is not in the correct state for the "
+             "performance of the indicated operation."
+          << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_REGISTER_VALUE:
+        LOG_MOD(INFO, HyperV)
+          << "The supplied register value is invalid." << LOG_ENDL;
+        break;
+      case HV_STATUS_INVALID_VTL_STATE:
+        LOG_MOD(INFO, HyperV)
+          << "The VTL state conflicts with the requested operation."
+          << LOG_ENDL;
+        break;
+      default:
+        LOG_MOD(INFO, HyperV) << "Unknown error " << status << "." << LOG_ENDL;
+        break;
+    };
+  }
+
+  static StatusCode
+  call_hyperv(SimpleCallCode code, void* input_params, void* output_params)
+  {
+    HyperCallInput hypercall_input;
+    hypercall_input.raw_uint64 = 0;
+    hypercall_input.call_code.simple = code;
+    HyperCallOutput return_value;
+    asm volatile("mov %1, %%r8; call *%2"
+                 : "=a"(return_value.raw_uint64)
+                 : "r"(output_params),
+                   "r"(hv_call_target),
+                   "c"(hypercall_input.raw_uint64),
+                   "d"(input_params)
+                 : "r8");
+    return return_value.status_code;
+  }
+
+  static StatusCode
+  call_hyperv_rep_one(RepCallCode code, void* input_params, void* output_params)
+  {
+    HyperCallInput hypercall_input;
+    hypercall_input.raw_uint64 = 0;
+    hypercall_input.call_code.rep = code;
+    hypercall_input.rep_count = 1;
+    HyperCallOutput return_value;
+    asm volatile("mov %1, %%r8; call *%2"
+                 : "=a"(return_value.raw_uint64)
+                 : "r"(output_params),
+                   "r"(hv_call_target),
+                   "c"(hypercall_input.raw_uint64),
+                   "d"(input_params)
+                 : "r8");
+    return return_value.status_code;
+  }
+
+  static StatusCode call_hyperv_rep(
+    RepCallCode code,
+    uint8_t rep_count,
+    void* input_params,
+    void* output_params)
+  {
+    HyperCallInput hypercall_input;
+    hypercall_input.raw_uint64 = 0;
+    hypercall_input.call_code.rep = code;
+    hypercall_input.rep_count = rep_count;
+    HyperCallOutput return_value;
+    asm volatile("mov %1, %%r8; call *%2"
+                 : "=a"(return_value.raw_uint64)
+                 : "r"(output_params),
+                   "r"(hv_call_target),
+                   "c"(hypercall_input.raw_uint64),
+                   "d"(input_params)
+                 : "r8");
+    return return_value.status_code;
+  }
+
+  static StatusCode call_hyperv_fast(
+    SimpleCallCode code, uint64_t input_params, uint64_t& output_params)
+  {
+    HyperCallInput hypercall_input;
+    hypercall_input.raw_uint64 = 0;
+    hypercall_input.call_code.simple = code;
+    hypercall_input.is_fast = 1;
+    HyperCallOutput return_value;
+    asm volatile(
+      "call *%2; mov %%r8, %1"
+      : "=a"(return_value.raw_uint64), "=r"(output_params)
+      : "r"(hv_call_target), "c"(hypercall_input.raw_uint64), "d"(input_params)
+      : "r8");
+    return return_value.status_code;
+  }
+
+  /**
+   * Use Hyper-V to retrieve the value for an array of registers of the CPU
+   * using their name. Do it using a single hypercall with repetition. Keeps the
+   * code simple for complex system registers (such as segments, GDT).
+   */
+  template<uint8_t N>
+  static void get_local_registers(
+    std::array<RegisterName, N>& names, std::array<RegisterValue, N>& values)
+  {
+    alignas(HV_PAGE_SIZE) GetRegisterParams<N> params{};
+    for (uint8_t i = 0; i < N; ++i)
+    {
+      params.input_elements[i].register_name = names[i];
+    }
+
+    StatusCode status = call_hyperv_rep(
+      HvCallGetVpRegisters, N, &params.input, &params.output_elements);
+    if (status != HV_STATUS_SUCCESS)
+    {
+      LOG_MOD(ERROR, HyperV)
+        << "Failed hypercall to HvCallGetVpRegisters." << LOG_ENDL;
+      print_hv_status(status);
+    }
+
+    for (uint8_t i = 0; i < N; ++i)
+    {
+      values[i] = params.output_elements[i].register_value;
+    }
+  }
+
+  /**
+   * Get the current TSC frequency.
+   * When running on Hyper-V we can just read an MSR for the value.
+   */
+  static void hv_set_tsc_freq()
+  {
+    extern uint64_t tsc_freq;
+
+    tsc_freq = read_msr_virt(HV_X64_MSR_TSC_FREQ);
+  }
+
+  /**
+   * Clone the current context in preparation of starting a new core.
+   */
+  static void
+  clone_initial_context(platform_core_id_t core, InitialVPContext& context)
+  {
+    constexpr uint8_t initial_context_registers = 18;
+
+    std::array<RegisterName, initial_context_registers> registers_cloned = {
+      HvX64RegisterRip,
+      HvX64RegisterRsp,
+      HvX64RegisterRflags,
+      HvX64RegisterCs,
+      HvX64RegisterDs,
+      HvX64RegisterEs,
+      HvX64RegisterFs,
+      HvX64RegisterGs,
+      HvX64RegisterSs,
+      HvX64RegisterTr,
+      HvX64RegisterLdtr,
+      HvX64RegisterIdtr,
+      HvX64RegisterGdtr,
+      HvX64RegisterEfer,
+      HvX64RegisterCr0,
+      HvX64RegisterCr3,
+      HvX64RegisterCr4,
+      HvX64RegisterPat};
+    std::array<RegisterValue, initial_context_registers>
+      registers_cloned_values;
+
+    get_local_registers<initial_context_registers>(
+      registers_cloned, registers_cloned_values);
+
+    context.rip = registers_cloned_values[0].reg64;
+    context.rsp = registers_cloned_values[1].reg64;
+    context.rflags = registers_cloned_values[2].flags;
+    context.cs = registers_cloned_values[3].segment;
+    context.ds = registers_cloned_values[4].segment;
+    context.es = registers_cloned_values[5].segment;
+    context.fs = registers_cloned_values[6].segment;
+    context.gs = registers_cloned_values[7].segment;
+    context.ss = registers_cloned_values[8].segment;
+    context.tr = registers_cloned_values[9].segment;
+    context.ldtr = registers_cloned_values[10].segment;
+    context.idtr = registers_cloned_values[11].table;
+    context.gdtr = registers_cloned_values[12].table;
+    context.efer = registers_cloned_values[13].reg64;
+    context.cr0 = registers_cloned_values[14].reg64;
+    context.cr3 = registers_cloned_values[15].reg64;
+    context.cr4 = registers_cloned_values[16].reg64;
+    context.msr_cr_pat = registers_cloned_values[17].reg64;
+  }
+
+  /**
+   * Start a new core based on the state of the current one, but using a new
+   * stack and thread/core state and targeting the ap_reset entry-point.
+   */
+  static void init_cpu_hyperv(platform_core_id_t core, void* sp, void* tls)
+  {
+    alignas(HV_PAGE_SIZE) StartVPInputParams input_params = {.vp_index = core};
+
+    clone_initial_context(PerCoreData::get()->core_id, input_params.context);
+    input_params.context.rip = snmalloc::address_cast(&ap_reset);
+    input_params.context.rsp = snmalloc::address_cast(sp);
+    input_params.context.fs.base = snmalloc::address_cast(tls);
+    input_params.context.gs.base =
+      snmalloc::address_cast(PerCoreData::get(core));
+    input_params.context.tr = gdt.tss[core];
+    // A loaded task segment register will have this bit set
+    input_params.context.tr.attributes.segment_type |= 1 << 1;
+
+    StatusCode status =
+      call_hyperv(HvCallStartVirtualProcessor, &input_params, nullptr);
+    if (status != HV_STATUS_SUCCESS)
+    {
+      LOG_MOD(ERROR, HyperV)
+        << "Failed hypercall to HvCallStartVirtualProcessor." << LOG_ENDL;
+      print_hv_status(status);
+    }
+  }
+
+  /**
+   * Check that the VM has the permissions needed for the necessary hypercalls.
+   */
+  static void check_features()
+  {
+    uint32_t eax;
+    uint32_t ebx;
+    uint32_t unused;
+    // Using __cpuid instead of __get_cpuid, since hypervisor leafs beyond max
+    // leaf count as the CPU reports.
+    __cpuid(HV_CPUID_FEATURES, eax, ebx, unused, unused);
+    uint64_t merged_result = eax | (static_cast<uint64_t>(ebx) << 32);
+    PartitionPriviledge* features = (PartitionPriviledge*)&merged_result;
+    if (features->AccessVpRegisters == 0)
+    {
+      LOG_MOD(WARNING, HyperV)
+        << "Missing AccessVpRegisters partition priviledge." << LOG_ENDL;
+    }
+    if (features->StartVirtualProcessor == 0)
+    {
+      LOG_MOD(WARNING, HyperV)
+        << "Missing StartVirtualProcessor partition priviledge." << LOG_ENDL;
+    }
+  }
+
+  static void setup_hypervisor_stage2_hyperv()
+  {
+    // Hyper-V maps the shared memory section just after the main memory.
+    io_shared_range = std::span<uint8_t, IO_SHARED_MEMORY_SIZE>(
+      snmalloc::unsafe_from_uintptr<uint8_t>(
+        HeapRanges::largest_valid_address() + 1),
+      IO_SHARED_MEMORY_SIZE);
+  }
+
+  static void ap_init_hyperv()
+  {
+    // To enable local APIC set the 8th bit of the Spurious Interrupt Vector
+    // Register located at offset 0xf0 in the lapic registers
+    uint32_t* spurious_intr_vector =
+      reinterpret_cast<uint32_t*>(local_apic_mapping + 0xf0);
+    *spurious_intr_vector |= 0x100;
+
+    PerCoreData::get()->hypervisor_input_page = allocate_visible(HV_PAGE_SIZE);
+  }
+
+  // Generic setup for HyperV
+  __attribute__((section(".data"))) uint8_t vtl = 0;
+  StatusCode (*call_hv)(
+    SimpleCallCode code,
+    void* input_params,
+    void* output_params) = &call_hyperv;
+  StatusCode (*call_hv_fast)(
+    SimpleCallCode code,
+    uint64_t input_params,
+    uint64_t& output_params) = call_hyperv_fast;
+
+  void init_hyperv(uint32_t cpuid_hypervisor_maxleaf)
+  {
+    LOG(INFO) << "HyperV detected. Initializing hypercalls." << LOG_ENDL;
+    check_features();
+    write_msr_virt(
+      HV_X64_MSR_GUEST_OS_ID,
+      static_cast<uint64_t>(MONZA_ID) << 48 |
+        static_cast<uint64_t>(KERNEL_VERSION) << 16 | BUILD_ID);
+    uint64_t hypercall_config = read_msr_virt(HV_X64_MSR_HYPERCALL);
+    if ((hypercall_config & HV_X64_MSR_HYPERCALL_ENABLED_FLAG) == 0)
+    {
+      hv_call_target = &__hv_hypercall_codepage_start;
+      hypercall_config |=
+        (reinterpret_cast<uint64_t>(hv_call_target) / HV_PAGE_SIZE) << 12;
+      hypercall_config |= HV_X64_MSR_HYPERCALL_ENABLED_FLAG;
+      write_msr_virt(HV_X64_MSR_HYPERCALL, hypercall_config);
+    }
+    else
+    {
+      hv_call_target =
+        reinterpret_cast<void*>((hypercall_config >> 12) * HV_PAGE_SIZE);
+    }
+
+    // HyperV-specific methods for boot setup
+    setup_hypervisor_stage2 = &setup_hypervisor_stage2_hyperv;
+    // HyperV-specific methods for core management
+    init_cpu = &init_cpu_hyperv;
+    ap_init = &ap_init_hyperv;
+
+    hv_set_tsc_freq();
+  }
+}

--- a/guest-verona-rt/arch/x86_64/inc/hv.h
+++ b/guest-verona-rt/arch/x86_64/inc/hv.h
@@ -1,0 +1,414 @@
+// Copyright Microsoft and Project Monza Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <gdt.h>
+
+namespace monza
+{
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/feature-discovery
+   */
+  constexpr char HV_SIGNATURE[] = "Microsoft Hv";
+  constexpr uint32_t HV_CPUID_MIN_MAXLEAF = 0x40000005;
+  constexpr uint32_t HV_CPUID_FEATURES = 0x40000003;
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/tlfs
+   * Appendix C.
+   */
+  constexpr uint32_t HV_X64_MSR_GUEST_OS_ID = 0x40000000;
+  constexpr uint32_t HV_X64_MSR_HYPERCALL = 0x40000001;
+  constexpr uint32_t HV_X64_MSR_VP_INDEX = 0x40000002;
+  constexpr uint32_t HV_X64_MSR_TSC_FREQ = 0x40000022;
+  constexpr uint64_t HV_X64_MSR_HYPERCALL_ENABLED_FLAG = 1 << 0;
+
+  typedef uint64_t partition_t;
+  typedef uint32_t vp_t;
+  typedef uint8_t vtl_t;
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/tlfs
+   * Section Alignment Requirements.
+   */
+  constexpr size_t HV_CALL_ALIGNMENT = 8;
+  constexpr size_t HV_PAGE_SIZE = 4096;
+
+  /**
+   * Magic value to be used as partition_id to signal operations on the current
+   * partition. Necessary since there is no way to query the partition ID for
+   * non-root guests. All operations in Monza apply only to the current
+   * partition.
+   *
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/tlfs
+   * Section Partition Properties.
+   */
+  constexpr partition_t HV_PARTITION_ID_SELF = static_cast<partition_t>(-1);
+  /**
+   * Magic value to be used as vp_index to signal operations on the current VP.
+   * Some hypercalls are limited to the only the current VP and require this
+   * marker to be used.
+   *
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/tlfs
+   * Section Virtual Process Management.
+   */
+  constexpr vp_t HV_VP_ID_SELF = static_cast<vp_t>(-2);
+
+  constexpr uint16_t MONZA_ID = 0x8000;
+  constexpr uint32_t KERNEL_VERSION = 0;
+  constexpr uint16_t BUILD_ID = 0;
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/tlfs
+   * Appendix B.
+   */
+  enum StatusCode : uint16_t
+  {
+    HV_STATUS_SUCCESS = 0x0,
+    HV_STATUS_INVALID_HYPERCALL_CODE = 0x2,
+    HV_STATUS_INVALID_ALIGNMENT = 0x4,
+    HV_STATUS_INVALID_PARAMETER = 0x5,
+    HV_STATUS_ACCESS_DENIED = 0x6,
+    HV_STATUS_INVALID_PARTITION_STATE = 0x7,
+    HV_STATUS_INVALID_PARTITION_ID = 0xd,
+    HV_STATUS_INVALID_VP_INDEX = 0xe,
+    HV_STATUS_INVALID_PORT_ID = 0x11,
+    HV_STATUS_INVALID_CONNECTION_ID = 0x12,
+    HV_STATUS_INSUFFICIENT_BUFFERS = 0x13,
+    HV_STATUS_INVALID_VP_STATE = 0x15,
+    HV_STATUS_INVALID_REGISTER_VALUE = 0x50,
+    HV_STATUS_INVALID_VTL_STATE = 0x51
+  };
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercalls/overview
+   */
+  enum SimpleCallCode : uint16_t
+  {
+    // Simple
+    HvCallEnableVpVtl = 0x0f,
+    HvCallStartVirtualProcessor = 0x99
+  };
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercalls/overview
+   */
+  enum RepCallCode : uint16_t
+  {
+    // Rep
+    HvCallGetVpRegisters = 0x50,
+  };
+
+  /**
+   * From:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/datatypes/hv_partition_privilege_mask
+   * Formatting might not match rest of the code, but keeping as it is for now.
+   */
+  struct PartitionPriviledge
+  {
+    // Access to virtual MSRs
+    uint64_t AccessVpRunTimeReg : 1;
+    uint64_t AccessPartitionReferenceCounter : 1;
+    uint64_t AccessSynicRegs : 1;
+    uint64_t AccessSyntheticTimerRegs : 1;
+    uint64_t AccessIntrCtrlRegs : 1;
+    uint64_t AccessHypercallMsrs : 1;
+    uint64_t AccessVpIndex : 1;
+    uint64_t AccessResetReg : 1;
+    uint64_t AccessStatsReg : 1;
+    uint64_t AccessPartitionReferenceTsc : 1;
+    uint64_t AccessGuestIdleReg : 1;
+    uint64_t AccessFrequencyRegs : 1;
+    uint64_t AccessDebugRegs : 1;
+    uint64_t AccessReenlightenmentControls : 1;
+    uint64_t Reserved1 : 18;
+
+    // Access to hypercalls
+    uint64_t CreatePartitions : 1;
+    uint64_t AccessPartitionId : 1;
+    uint64_t AccessMemoryPool : 1;
+    uint64_t Reserved2 : 1;
+    uint64_t PostMessages : 1;
+    uint64_t SignalEvents : 1;
+    uint64_t CreatePort : 1;
+    uint64_t ConnectPort : 1;
+    uint64_t AccessStats : 1;
+    uint64_t Reserved3 : 2;
+    uint64_t Debugging : 1;
+    uint64_t CpuManagement : 1;
+    uint64_t Reserved4 : 1;
+    uint64_t Reserved5 : 1;
+    uint64_t Reserved6 : 1;
+    uint64_t AccessVSM : 1;
+    uint64_t AccessVpRegisters : 1;
+    uint64_t Reserved7 : 1;
+    uint64_t Reserved8 : 1;
+    uint64_t EnableExtendedHypercalls : 1;
+    uint64_t StartVirtualProcessor : 1;
+    uint64_t Reserved9 : 10;
+  } __attribute__((packed));
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/datatypes/hv_register_name
+   */
+  enum RegisterName : uint32_t
+  {
+    HvX64RegisterRsp = 0x00020004,
+    HvX64RegisterRip = 0x00020010,
+    HvX64RegisterRflags = 0x00020011,
+    HvX64RegisterCr0 = 0x00040000,
+    HvX64RegisterCr2 = 0x00040001,
+    HvX64RegisterCr3 = 0x00040002,
+    HvX64RegisterCr4 = 0x00040003,
+    HvX64RegisterCr5 = 0x00040004,
+    HvX64RegisterEs = 0x00060000,
+    HvX64RegisterCs = 0x00060001,
+    HvX64RegisterSs = 0x00060002,
+    HvX64RegisterDs = 0x00060003,
+    HvX64RegisterFs = 0x00060004,
+    HvX64RegisterGs = 0x00060005,
+    HvX64RegisterLdtr = 0x00060006,
+    HvX64RegisterTr = 0x00060007,
+    HvX64RegisterIdtr = 0x00070000,
+    HvX64RegisterGdtr = 0x00070001,
+    HvX64RegisterEfer = 0x00080001,
+    HvX64RegisterPat = 0x00080004,
+  };
+
+  /**
+   * Extra type enforcement to help using the right enum.
+   */
+  union CallCode
+  {
+    SimpleCallCode simple;
+    RepCallCode rep;
+  };
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercall-interface
+   */
+  union HyperCallInput
+  {
+    struct
+    {
+      CallCode call_code;
+      uint16_t is_fast : 1;
+      uint16_t variable_header_size : 9;
+      uint16_t reserved1 : 6;
+      uint32_t rep_count : 12;
+      uint32_t reserved2 : 4;
+      uint32_t rep_start_index : 12;
+      uint32_t reserved3 : 4;
+    } __attribute__((packed));
+    uint64_t raw_uint64;
+  };
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercall-interface
+   */
+  union HyperCallOutput
+  {
+    struct
+    {
+      StatusCode status_code;
+      uint16_t reserved1;
+      uint32_t elements_processed : 12;
+      uint32_t reserved2 : 20;
+    } __attribute__((packed));
+    uint64_t raw_uint64;
+  };
+
+  /**
+   * Based on: https://wiki.osdev.org/CPU_Registers_x86
+   */
+  struct FlagsRegister
+  {
+    uint64_t carry : 1;
+    uint64_t reserved_one : 1;
+    uint64_t parity : 1;
+    uint64_t reserved : 1;
+    uint64_t adjust : 1;
+    uint64_t reserved2 : 1;
+    uint64_t zero : 1;
+    uint64_t sign : 1;
+    uint64_t trap : 1;
+    uint64_t interrupt_enable : 1;
+    uint64_t direction : 1;
+    uint64_t overflow : 1;
+    uint64_t io_priviledge : 2;
+    uint64_t nested_task : 1;
+    uint64_t reserved_zero : 1;
+    uint64_t resume : 1;
+    uint64_t virtual_8086 : 1;
+    uint64_t alignment_check : 1;
+    uint64_t virtual_interrupt : 1;
+    uint64_t virtual_interrupt_pending : 1;
+    uint64_t cpuid_available : 1;
+    uint64_t reserved3 : 42;
+  } __attribute__((packed));
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/datatypes/hv_x64_segment_register
+   */
+  struct SegmentRegister
+  {
+    uint64_t base;
+    uint32_t limit;
+    uint16_t selector;
+    SegmentAttributes attributes;
+
+    SegmentRegister() = default;
+
+    SegmentRegister(SystemGDTEntry& gdt_entry)
+    {
+      base = gdt_entry.common.base_low | gdt_entry.common.base_high << 24 |
+        gdt_entry.base_high << 32;
+      limit = gdt_entry.common.limit_low |
+        gdt_entry.common.attributes.limit_high << 16;
+      selector = snmalloc::pointer_diff(&gdt, &gdt_entry) |
+        gdt_entry.common.attributes.descriptor_privilege_level;
+      attributes = gdt_entry.common.attributes;
+    }
+  } __attribute__((packed));
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/datatypes/hv_x64_table_register
+   */
+  struct TableRegister
+  {
+    uint16_t padding[3];
+    uint16_t limit;
+    uint64_t base;
+  } __attribute__((packed));
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/datatypes/hv_register_value
+   */
+  union RegisterValue
+  {
+    __uint128_t reg128;
+    uint64_t reg64;
+    uint32_t reg32;
+    uint16_t Reg16;
+    uint8_t reg8;
+    FlagsRegister flags;
+    SegmentRegister segment;
+    TableRegister table;
+  };
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercalls/hvcallgetvpregisters
+   */
+  struct GetRegisterInputParams
+  {
+    partition_t partition_id = HV_PARTITION_ID_SELF;
+    vp_t vp_index = HV_VP_ID_SELF;
+    vtl_t target_vtl = 0;
+    uint8_t padding[3] = {};
+  } __attribute__((packed));
+
+  static_assert(sizeof(GetRegisterInputParams) % HV_CALL_ALIGNMENT == 0);
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercalls/hvcallgetvpregisters
+   */
+  struct GetRegisterInputListElement
+  {
+    RegisterName register_name;
+  } __attribute__((packed));
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercalls/hvcallgetvpregisters
+   */
+  struct GetRegisterOutputListElement
+  {
+    RegisterValue register_value;
+  } __attribute__((packed));
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercalls/hvcallgetvpregisters
+   */
+  template<uint8_t N>
+  struct GetRegisterParams
+  {
+    GetRegisterInputParams input;
+    GetRegisterInputListElement input_elements[N];
+    alignas(HV_CALL_ALIGNMENT) GetRegisterOutputListElement output_elements[N];
+  } __attribute__((packed));
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/datatypes/hv_initial_vp_context
+   */
+  struct InitialVPContext
+  {
+    uint64_t rip;
+    uint64_t rsp;
+    FlagsRegister rflags;
+
+    // Segment selector registers together with their hidden state.
+    SegmentRegister cs;
+    SegmentRegister ds;
+    SegmentRegister es;
+    SegmentRegister fs;
+    SegmentRegister gs;
+    SegmentRegister ss;
+    SegmentRegister tr;
+    SegmentRegister ldtr;
+
+    // Global and Interrupt Descriptor tables
+    TableRegister idtr;
+    TableRegister gdtr;
+
+    // Control registers and MSR's
+    uint64_t efer;
+    uint64_t cr0;
+    uint64_t cr3;
+    uint64_t cr4;
+    uint64_t msr_cr_pat;
+  } __attribute__((packed));
+
+  /**
+   * Based on:
+   * https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/hypercalls/hvcallstartvirtualprocessor
+   */
+  struct StartVPInputParams
+  {
+    partition_t partition_id = HV_PARTITION_ID_SELF;
+    uint32_t vp_index;
+    vtl_t target_vtl = 0;
+    uint8_t padding[3] = {};
+    InitialVPContext context;
+  } __attribute__((packed));
+
+  static_assert(sizeof(StartVPInputParams) % HV_CALL_ALIGNMENT == 0);
+
+  void init_hyperv(uint32_t cpuid_hypervisor_maxleaf);
+
+  extern StatusCode (*call_hv)(
+    SimpleCallCode code, void* input_params, void* output_params);
+  extern StatusCode (*call_hv_fast)(
+    SimpleCallCode code, uint64_t input_params, uint64_t& output_params);
+  extern void print_hv_status(StatusCode status);
+  extern uint8_t vtl;
+}

--- a/guest-verona-rt/arch/x86_64/inc/shared_arch.h
+++ b/guest-verona-rt/arch/x86_64/inc/shared_arch.h
@@ -1,0 +1,14 @@
+// Copyright Microsoft and Project Monza Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdlib>
+#include <shared.h>
+
+namespace monza
+{
+  constexpr size_t IO_SHARED_MEMORY_SIZE = 64 * 1024 * 1024;
+
+  extern std::span<uint8_t, IO_SHARED_MEMORY_SIZE> io_shared_range;
+}

--- a/guest-verona-rt/arch/x86_64/main64.asm
+++ b/guest-verona-rt/arch/x86_64/main64.asm
@@ -2,6 +2,7 @@
 ; SPDX-License-Identifier: MIT
 
 global start
+global triple_fault
 
 extern __early_stack_start
 extern __early_stack_end
@@ -91,3 +92,15 @@ start:
     call startcc
 
     jmp [shutdown]
+
+; Trigger triple fault
+triple_fault:
+    lidt [fake_idtr]
+    int 0
+    ; Should never reach this point
+    ret
+
+align 16
+fake_idtr:                      ; Fake Interrupt Descriptor Table Register
+                dw 1            ; Size (minus one), size of 0 makes it unusable
+                dq 0            ; Base address

--- a/guest-verona-rt/arch/x86_64/shared.cc
+++ b/guest-verona-rt/arch/x86_64/shared.cc
@@ -1,0 +1,18 @@
+
+// Copyright Microsoft and Project Monza Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <shared_arch.h>
+
+namespace monza
+{
+  // Ensure that this is in the data section, since the BSS might not be fully
+  // mapped at boot.
+  __attribute__((section(".data"))) std::span<uint8_t, IO_SHARED_MEMORY_SIZE>
+    io_shared_range(nullptr, IO_SHARED_MEMORY_SIZE);
+
+  std::span<uint8_t> get_io_shared_range()
+  {
+    return io_shared_range;
+  }
+}

--- a/guest-verona-rt/include/public/pagetable.h
+++ b/guest-verona-rt/include/public/pagetable.h
@@ -29,5 +29,4 @@ namespace monza
     PagetablePermission perm);
   void remove_from_compartment_pagetable(
     void* root, snmalloc::address_t base, size_t size);
-  std::span<uint8_t> get_io_shared_range();
 }

--- a/guest-verona-rt/include/public/shared.h
+++ b/guest-verona-rt/include/public/shared.h
@@ -1,0 +1,12 @@
+// Copyright Microsoft and Project Monza Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+namespace monza
+{
+  std::span<uint8_t> get_io_shared_range();
+}

--- a/guest-verona-rt/test/io/shmem/main.cc
+++ b/guest-verona-rt/test/io/shmem/main.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <cstdint>
-#include <pagetable.h>
+#include <shared.h>
 #include <snmalloc.h>
 #include <test.h>
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15)
+
+include(CMakePrintHelpers)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+project(
+  monza_windows
+  LANGUAGES CXX
+)
+
+set(APPS_INSTALL ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/apps)
+
+add_subdirectory(apps/example)

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,24 @@
+# Windows host for the application framework.
+
+**WARNING** Code in this folder is highly experimental, it is likely that it will not work on your machine.
+We apologise, but we don't have the cycles to prioritise fixing bugs in this code for now.
+
+This folder implements a Windows host option for the application framework.
+The goal is that an application developer could reuse the same source files they used to implement the Linux host and just recompile it on Windows.
+Obviously, the host code needs to be written in a cross-platform way to leverage this ability.
+The guest image will be the same ELF guest as on Linux and needs to be copied over.
+On Windows currently use the [Host Compute System](https://learn.microsoft.com/en-us/virtualization/api/hcs/overview) to run and manage our guest VM.
+
+## Requirements
+
+Currently we use a `CMake` + `ninja` + `clang` build pipeline to ensure that we are as closely matched with the Linux build as possible.
+* `clang`: 13.0.1 Windows release to best match the other builds.
+* `MSVC`: 14.33.
+* `Win11 SDK`: 10.0.22000.
+
+## Usage
+
+Link your host code with the new `monza-app-host` target in the local `app-framework/host` instead of the one in the original location.
+No need to build the guest code as that needs to happen on Linux.
+The image file to use with this host is the simple ELF guest image (not the QEMU artefact).
+An example is included in `apps/example`.

--- a/windows/app-framework/CMakeLists.txt
+++ b/windows/app-framework/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.15)
+
+include(CMakePrintHelpers)
+
+set(CCF_REPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../external/CCF)
+
+unset(SRC)
+set(SRC
+  ${SRC}
+  host/hcs_enclave.cc)
+add_library(monza-app-host STATIC ${SRC})
+target_compile_definitions(monza-app-host PRIVATE
+  _AMD64_
+)
+target_include_directories(monza-app-host PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../app-framework/include/host
+)
+target_compile_definitions(monza-app-host INTERFACE
+  MONZA_HOST_SUPPORTS_HCS
+  CCF_LOGGER_NO_DEPRECATE
+)
+target_include_directories(monza-app-host INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../app-framework/include/common
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../app-framework/include/host
+  ${CCF_REPO_DIR}/include
+  ${CCF_REPO_DIR}/src
+  ${CCF_REPO_DIR}/3rdparty/exported
+)
+target_compile_options(monza-app-host INTERFACE
+  -include ${CMAKE_CURRENT_SOURCE_DIR}/../include/nix2win.h
+)
+target_link_libraries(monza-app-host INTERFACE
+  computecore rpcrt4 ntdll
+)

--- a/windows/app-framework/host/hcs_enclave.cc
+++ b/windows/app-framework/host/hcs_enclave.cc
@@ -189,7 +189,7 @@ public:
 };
 
 /**
- * Create a memory section in the global space with full access to "everyone".
+ * Create a memory section with full access to "everyone".
  * Uses Win32 naming scheme as it is helper for Win32.
  */
 static HANDLE CreateSection(std::wstring name, size_t size)

--- a/windows/app-framework/host/hcs_enclave.cc
+++ b/windows/app-framework/host/hcs_enclave.cc
@@ -1,0 +1,499 @@
+// Copyright Microsoft and Project Monza Contributors.
+// SPDX-License-Identifier: MIT
+
+/**
+ * This file needs to mix C++20 and Win32 to access HostComputeServices APIs.
+ * As such, the functionality is encapsulated in a source file to avoid
+ * impacting other files. No other file needs to include "windows.h" or other
+ * Win32 headers.
+ */
+
+#include <ComputeCore.h>
+#include <aclapi.h>
+#include <array>
+#include <filesystem>
+#include <format>
+#include <functional>
+#include <hcs_enclave.h>
+#include <iostream>
+#include <stdexcept>
+#include <windows.h>
+
+template<typename T>
+using RaiiHandle = std::
+  unique_ptr<typename std::remove_pointer<T>::type, std::function<void(T)>>;
+
+/**
+ * Convert HRESULT to system error message.
+ * Uses Win32 naming scheme as it is helper for Win32.
+ */
+std::string GetErrorMessage(DWORD error_code)
+{
+  char character_array[1024];
+  auto characters = FormatMessage(
+    FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_FROM_HMODULE |
+      FORMAT_MESSAGE_IGNORE_INSERTS,
+    NULL,
+    error_code,
+    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+    character_array,
+    std::size(character_array),
+    NULL);
+  if (characters > 0)
+  {
+    return std::string(character_array, characters);
+  }
+  else
+  {
+    return std::format(
+      "Failed to retrieve error message string for error {:#x}.",
+      static_cast<uint32_t>(error_code));
+  }
+}
+
+/**
+ * Converts a GUID to a UNICODE string.
+ * Uses Win32 naming scheme as it is helper for Win32.
+ */
+static std::wstring GuidToString(REFGUID guid)
+{
+  RPC_WSTR guid_string{};
+  RPC_STATUS rpc_status = UuidToStringW(&guid, &guid_string);
+  if (rpc_status != RPC_S_OK)
+  {
+    throw std::runtime_error("Out of memory when converting GUID to string.");
+  }
+  try
+  {
+    std::wstring result(reinterpret_cast<LPCWSTR>(guid_string));
+    RpcStringFreeW(&guid_string);
+    return result;
+  }
+  catch (...)
+  {
+    RpcStringFreeW(&guid_string);
+    throw;
+  }
+}
+
+/**
+ * Call HcsWaitForOperationResult and process any reported errors.
+ * Uses Win32 naming scheme as it is helper for Win32.
+ */
+static void HcsWaitForOperationResultAndReportError(HCS_OPERATION operation)
+{
+  PWSTR report_raw = nullptr;
+  HRESULT result = HcsWaitForOperationResult(operation, INFINITE, &report_raw);
+  if (FAILED(result))
+  {
+    RaiiHandle<PWSTR> report(report_raw, LocalFree);
+    std::wstring report_string(report.get());
+    throw std::runtime_error(std::format(
+      "HcsWaitForOperationResult failed. {}",
+      std::string(report_string.begin(), report_string.end())));
+  }
+}
+
+/**
+ * Based on
+ * https://learn.microsoft.com/en-us/windows/win32/secauthz/creating-a-security-descriptor-for-a-new-object-in-c--
+ */
+class SecurityAttributes
+{
+  RaiiHandle<PSID> sid_everyone{nullptr, FreeSid};
+  RaiiHandle<PACL> acl{nullptr, LocalFree};
+  RaiiHandle<PSECURITY_DESCRIPTOR> descriptor{
+    LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH), LocalFree};
+  SECURITY_ATTRIBUTES implementation{.nLength = sizeof(SECURITY_ATTRIBUTES),
+                                     .lpSecurityDescriptor = descriptor.get(),
+                                     .bInheritHandle = false};
+
+  SecurityAttributes() {}
+
+public:
+  PSECURITY_ATTRIBUTES get_pointer()
+  {
+    return &implementation;
+  }
+
+  static SecurityAttributes everyone_full()
+  {
+    SecurityAttributes result{};
+
+    // Single ACL entry to authorise the "everyone" SID.
+    EXPLICIT_ACCESS access[1]{};
+
+    // Create the SID object for the "everyone".
+    SID_IDENTIFIER_AUTHORITY sid_auth_world = SECURITY_WORLD_SID_AUTHORITY;
+    PSID sid_raw = nullptr;
+    if (!AllocateAndInitializeSid(
+          &sid_auth_world,
+          1,
+          SECURITY_WORLD_RID,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          &sid_raw))
+    {
+      throw std::runtime_error(std::format(
+        "AllocateAndInitializeSid failed. {}",
+        GetErrorMessage(::GetLastError())));
+    }
+    result.sid_everyone.reset(sid_raw);
+
+    access[0].grfAccessPermissions = FILE_ALL_ACCESS;
+    access[0].grfAccessMode = SET_ACCESS;
+    access[0].grfInheritance = NO_INHERITANCE;
+    access[0].Trustee.TrusteeForm = TRUSTEE_IS_SID;
+    access[0].Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+    access[0].Trustee.ptstrName =
+      reinterpret_cast<LPTSTR>(result.sid_everyone.get());
+
+    // Create the ACL out of the entries.
+    PACL acl_raw;
+    auto response = SetEntriesInAcl(std::size(access), access, NULL, &acl_raw);
+    if (response != ERROR_SUCCESS)
+    {
+      throw std::runtime_error(std::format(
+        "SetEntriesInAcl failed. {}", GetErrorMessage(::GetLastError())));
+    }
+    result.acl.reset(acl_raw);
+
+    // Initialize the security descriptor.
+    if (!InitializeSecurityDescriptor(
+          result.descriptor.get(), SECURITY_DESCRIPTOR_REVISION))
+    {
+      throw std::runtime_error(std::format(
+        "InitializeSecurityDescriptor failed. {}",
+        GetErrorMessage(::GetLastError())));
+    }
+
+    // Add the ACL to the security descriptor.
+    if (!SetSecurityDescriptorDacl(
+          result.descriptor.get(),
+          TRUE, // bDaclPresent flag
+          result.acl.get(),
+          FALSE)) // not a default DACL
+    {
+      throw std::runtime_error(std::format(
+        "SetSecurityDescriptorDacl failed. {}",
+        GetErrorMessage(::GetLastError())));
+    }
+
+    return result;
+  }
+};
+
+/**
+ * Create a memory section in the global space with full access to "everyone".
+ * Uses Win32 naming scheme as it is helper for Win32.
+ */
+static HANDLE CreateSection(std::wstring name, size_t size)
+{
+  auto security_attributes = SecurityAttributes::everyone_full();
+  LARGE_INTEGER object_size{};
+  object_size.QuadPart = size;
+  auto section = CreateFileMappingW(
+    INVALID_HANDLE_VALUE,
+    security_attributes.get_pointer(),
+    PAGE_READWRITE | SEC_COMMIT,
+    object_size.HighPart,
+    object_size.LowPart,
+    name.c_str());
+  if (section == NULL)
+  {
+    throw std::runtime_error(std::format(
+      "Creating section failed. {}", GetErrorMessage(::GetLastError())));
+  }
+
+  return section;
+}
+
+/**
+ * Adds escape characters to a file path for use in a JSON document.
+ */
+static std::wstring escape_file_path(const std::wstring& FilePath)
+{
+  std::wostringstream out;
+  for (auto& c : FilePath)
+  {
+    switch (c)
+    {
+      case L'\\':
+        out << L"\\\\";
+        break;
+      default:
+        out << c;
+        break;
+    }
+  }
+  return out.str();
+}
+
+namespace monza::host
+{
+  class HCSEnclave : public HCSEnclaveAbstract
+  {
+    static constexpr size_t RAM_SIZE_IN_MB = 1 * 1024;
+    static constexpr std::wstring_view SECTION_TEMPLATE =
+      L"hcsenclave-memory-{}";
+    static constexpr std::wstring_view HCS_SECTION_TEMPLATE =
+      L"\\Sessions\\{}\\BaseNamedObjects\\{}";
+    static constexpr std::wstring_view PIPE_TEMPLATE =
+      L"\\\\.\\pipe\\hcsenclave-{}";
+    static constexpr std::wstring_view CONFIG_TEMPLATE =
+      LR"***(
+{{
+  "Owner": "HCSEnclave",
+  "SchemaVersion": {{
+    "Major": 2,
+    "Minor": 6
+  }},
+  "VirtualMachine": {{
+    "StopOnReset": true,
+    "Chipset": {{
+      "LinuxKernelDirect": {{
+        "KernelFilePath": "{}"
+      }}
+    }},
+    "ComputeTopology": {{
+      "Memory": {{
+        "SizeInMB": {},
+        "AllowOvercommit": true
+      }},
+      "Processor": {{
+        "Count": {}
+      }}
+    }},
+    "Devices": {{
+      "ComPorts": {{
+        "0": {{
+          "NamedPipe": "{}"
+        }}
+      }},
+      "SharedMemory": {{
+        "Regions": [{{
+          "SectionName": "{}",
+          "StartOffset": 0,
+          "Length": {},
+          "AllowGuestWrite": false
+        }}]
+      }}
+    }}
+  }},
+  "ShouldTerminateOnLastHandleClosed": true
+}}
+)***";
+
+    /**
+     * The constructor of the class might throw exceptions.
+     * All class members managing resources need automatic clean-up.
+     */
+
+    GUID system_id{};
+    RaiiHandle<HCS_SYSTEM> hcs_system = {nullptr, HcsCloseComputeSystem};
+    RaiiHandle<HANDLE> shared_section = {nullptr, CloseHandle};
+    RaiiHandle<uint8_t*> shared_memory_mapping = {nullptr, UnmapViewOfFile};
+    std::atomic<bool> finished = false;
+    // Make sure that the thread can join on destruction.
+    RaiiHandle<std::thread*> pipe_listener{nullptr,
+                                           [finished = &finished](auto t) {
+                                             finished->store(true);
+                                             t->join();
+                                             delete (t);
+                                           }};
+    bool started = false;
+
+    HCSEnclave(
+      const std::string& image_path,
+      size_t num_threads,
+      size_t shared_memory_size)
+    : HCSEnclaveAbstract(image_path, num_threads, shared_memory_size)
+    {
+      HRESULT result = S_OK;
+      // Unique id to allow multiple instances on the same machine.
+      result = CoCreateGuid(&system_id);
+      if (FAILED(result))
+      {
+        throw std::runtime_error(
+          std::format("CoCreateGuid failed. {}", GetErrorMessage(result)));
+      }
+      auto id_string = GuidToString(system_id);
+      std::wcout << "Compute system ID: " << id_string << std::endl;
+
+      // The operation is used to track completion of the async methods.
+      RaiiHandle<HCS_OPERATION> operation(
+        HcsCreateOperation(nullptr, nullptr), HcsCloseOperation);
+      if (operation.get() == nullptr)
+      {
+        throw std::runtime_error(std::format(
+          "HcsCreateOperation failed. {}", GetErrorMessage(result)));
+      }
+
+      // Create named section to be used as shared region.
+      auto section_name = std::format(SECTION_TEMPLATE, id_string);
+      shared_section.reset(CreateSection(section_name, shared_memory_size));
+      shared_memory_mapping.reset(static_cast<uint8_t*>(MapViewOfFile(
+        shared_section.get(), FILE_MAP_ALL_ACCESS, 0, 0, shared_memory_size)));
+
+      // Fill in the details of the config template.
+      auto path = std::filesystem::canonical(std::filesystem::path(image_path));
+      auto pipe_name = std::format(PIPE_TEMPLATE, id_string);
+      DWORD session_id;
+      ProcessIdToSessionId(GetCurrentProcessId(), &session_id);
+      auto hcs_section_name =
+        std::format(HCS_SECTION_TEMPLATE, session_id, section_name);
+      auto config = std::format(
+        CONFIG_TEMPLATE,
+        escape_file_path(path.wstring()),
+        RAM_SIZE_IN_MB,
+        num_threads,
+        escape_file_path(pipe_name),
+        escape_file_path(hcs_section_name),
+        shared_memory_size);
+      std::wcout << "Compute system config: " << config << std::endl;
+
+      // Create the compute system and wait for the operation to finish.
+      HCS_SYSTEM system_handle;
+      result = HcsCreateComputeSystem(
+        id_string.c_str(),
+        config.c_str(),
+        operation.get(),
+        nullptr,
+        &system_handle);
+      if (FAILED(result))
+      {
+        throw std::runtime_error(std::format(
+          "HcsCreateComputeSystem failed. {}", GetErrorMessage(result)));
+      }
+      HcsWaitForOperationResultAndReportError(operation.get());
+      hcs_system.reset(system_handle);
+
+      // Create a listener thread for the named pipe used for debug output.
+      pipe_listener.reset(new std::thread([pipe_name = std::move(pipe_name),
+                                           &finished = finished]() {
+        RaiiHandle<HANDLE> pipe(
+          CreateFileW(
+            pipe_name.c_str(),
+            GENERIC_READ,
+            0,
+            NULL,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            NULL),
+          CloseHandle);
+        if (pipe.get() == INVALID_HANDLE_VALUE)
+        {
+          throw std::runtime_error(std::format(
+            "Opening named pipe failed. {}", GetErrorMessage(GetLastError())));
+        }
+        while (!finished.load())
+        {
+          char buffer[1024];
+          DWORD bytes_read = 0;
+          // Read up to size - 1 bytes to allow space for NUL terminator.
+          if (!ReadFile(
+                pipe.get(), buffer, std::size(buffer) - 1, &bytes_read, NULL))
+          {
+            break;
+          }
+          if (bytes_read > 0)
+          {
+            buffer[bytes_read] = '\0';
+            std::cout << buffer;
+          }
+        }
+        std::cout << std::endl;
+        std::cout << "Finished reading named pipe." << std::endl;
+      }));
+    }
+
+  public:
+    size_t shared_memory_guest_base() override
+    {
+      return RAM_SIZE_IN_MB * 1024 * 1024;
+    }
+
+    std::span<uint8_t> shared_memory() override
+    {
+      return std::span(shared_memory_mapping.get(), shared_memory_size);
+    }
+
+    void async_run() override
+    {
+      HRESULT result = S_OK;
+      // The operation is used to track completion of the async methods.
+      RaiiHandle<HCS_OPERATION> operation(
+        HcsCreateOperation(nullptr, nullptr), HcsCloseOperation);
+      if (operation.get() == nullptr)
+      {
+        throw std::runtime_error(std::format(
+          "HcsCreateOperation failed. {}", GetErrorMessage(result)));
+      }
+      result =
+        HcsStartComputeSystem(hcs_system.get(), operation.get(), nullptr);
+      if (FAILED(result))
+      {
+        throw std::runtime_error(std::format(
+          "HcsStartComputeSystem failed. {}", GetErrorMessage(result)));
+      }
+      HcsWaitForOperationResultAndReportError(operation.get());
+      started = true;
+    }
+
+    void join() override
+    {
+      if (started)
+      {
+        HRESULT result = S_OK;
+        // Create a Win32 Event to wait on.
+        RaiiHandle<HANDLE> system_exit(
+          CreateEventEx(nullptr, nullptr, 0, MAXIMUM_ALLOWED), CloseHandle);
+        if (system_exit.get() == nullptr)
+        {
+          throw std::runtime_error(std::format(
+            "CreateEventEx failed. {}", GetErrorMessage(GetLastError())));
+        }
+        // Convert specific HCS_EVENTs into the Win32 event firing.
+        result = HcsSetComputeSystemCallback(
+          hcs_system.get(),
+          HcsEventOptionNone,
+          system_exit.get(),
+          [](HCS_EVENT* event, void* context) {
+            if (
+              event->Type == HcsEventSystemExited ||
+              event->Type == HcsEventServiceDisconnect)
+            {
+              SetEvent(reinterpret_cast<HANDLE>(context));
+            }
+          });
+        // Waiting on all possible stopping conditions.
+        // For now this is only the Win32 event, but future-proofing.
+        const HANDLE stopping_conditions[] = {system_exit.get()};
+        WaitForMultipleObjects(
+          static_cast<DWORD>(std::size(stopping_conditions)),
+          stopping_conditions,
+          FALSE,
+          INFINITE);
+      }
+      started = false;
+      // Notify the pipe listener that execution finished.
+      finished.store(true);
+    }
+
+    friend HCSEnclaveAbstract;
+  };
+
+  std::unique_ptr<HCSEnclaveAbstract> HCSEnclaveAbstract::create(
+    const std::string& image_path,
+    size_t num_threads,
+    size_t shared_memory_size)
+  {
+    return std::unique_ptr<HCSEnclave>(
+      new HCSEnclave(image_path, num_threads, shared_memory_size));
+  }
+}

--- a/windows/app-framework/host/hcs_enclave.cc
+++ b/windows/app-framework/host/hcs_enclave.cc
@@ -391,7 +391,8 @@ namespace monza::host
           if (pipe.get() == INVALID_HANDLE_VALUE)
           {
             throw std::runtime_error(std::format(
-              "Opening named pipe failed. {}", GetErrorMessage(GetLastError())));
+              "Opening named pipe failed. {}",
+              GetErrorMessage(GetLastError())));
           }
           while (!finished.load())
           {

--- a/windows/apps/example/CMakeLists.txt
+++ b/windows/apps/example/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.15)
+
+include(CMakePrintHelpers)
+
+project(
+  monza_example_app
+  LANGUAGES CXX
+)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
+
+add_subdirectory(../../app-framework app-framework EXCLUDE_FROM_ALL)
+
+unset(SRC)
+set(SRC
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../apps/example/host.cc
+)
+add_executable(apps-example-host ${SRC})
+target_link_libraries(apps-example-host PRIVATE monza-app-host)
+
+add_custom_target(apps-example ALL)
+add_dependencies(apps-example apps-example-host)
+
+install(TARGETS apps-example-host
+  DESTINATION ${APPS_INSTALL}
+)

--- a/windows/include/nix2win.h
+++ b/windows/include/nix2win.h
@@ -1,0 +1,15 @@
+// Copyright Microsoft and Project Monza Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <time.h>
+
+struct tm* gmtime_r(const time_t* time, struct tm* result)
+{
+  if (gmtime_s(result, time) != 0)
+  {
+    return nullptr;
+  }
+  return result;
+}


### PR DESCRIPTION
This is highly experimental work to show that one can build a cross-platform host that can run the Monza guest both on Linux and Windows.
- Initial support for Hyper-V as a hypervisor, including core bring-up, TSC frequency and shared memory region.
- Host backend to manage guest on Windows using HCS interface.
- README to describe usage and requirements.