### PR TITLE
Removed CCF document generation and tests from component governance

### DIFF
--- a/devops/AnyBuild.yml
+++ b/devops/AnyBuild.yml
@@ -128,7 +128,7 @@ jobs:
 
   - task: ComponentGovernanceComponentDetection@0
     inputs:
-      ignoreDirectories: 'external/llvm-project/mlir,external/llvm-project/lldb,external/llvm-project/utils,external/llvm-project/clang/utils,external/llvm-project/libcxx/utils,external/llvm-project/llvm/utils'
+      ignoreDirectories: 'external/llvm-project/mlir,external/llvm-project/lldb,external/llvm-project/utils,external/llvm-project/clang/utils,external/llvm-project/libcxx/utils,external/llvm-project/llvm/utils,external/CCF/doc,external/CCF/tests'
       scanType: 'Register'
       verbosity: 'Verbose'
       alertWarningLevel: 'High'

--- a/devops/CI.yml
+++ b/devops/CI.yml
@@ -71,7 +71,7 @@ jobs:
 
   - task: ComponentGovernanceComponentDetection@0
     inputs:
-      ignoreDirectories: 'external/llvm-project/mlir,external/llvm-project/lldb,external/llvm-project/utils,external/llvm-project/clang/utils,external/llvm-project/libcxx/utils,external/llvm-project/llvm/utils'
+      ignoreDirectories: 'external/llvm-project/mlir,external/llvm-project/lldb,external/llvm-project/utils,external/llvm-project/clang/utils,external/llvm-project/libcxx/utils,external/llvm-project/llvm/utils,external/CCF/doc,external/CCF/test'
       scanType: 'Register'
       verbosity: 'Verbose'
       alertWarningLevel: 'High'


### PR DESCRIPTION
- We are not using these parts of CCF as part of Monza so any issues discovered there are not applicable to us.
- Leaving the other parts of CCF as tracked in case something is fixed in upstream and we need to apply the fix to our submodule.

- Ended up needing to upgrade libcxxrt as the old commit could not be found anymore.