### PR TITLE
Moved to using clang-cl on Windows and small fixes to build

### DIFF
--- a/apps/example/host.cc
+++ b/apps/example/host.cc
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
   try
   {
     monza::host::RingbufferGuest guest(enclave_type, guest_path, 1);
-    std::cout << "Create guest instance using path " << guest_path << std::endl;
+    std::cout << "Created guest instance using path " << guest_path << std::endl;
     messaging::BufferProcessor bp("Host");
 
     // Set up handler for pong to be used while polling.

--- a/apps/example/host.cc
+++ b/apps/example/host.cc
@@ -35,7 +35,8 @@ int main(int argc, char** argv)
   try
   {
     monza::host::RingbufferGuest guest(enclave_type, guest_path, 1);
-    std::cout << "Created guest instance using path " << guest_path << std::endl;
+    std::cout << "Created guest instance using path " << guest_path
+              << std::endl;
     messaging::BufferProcessor bp("Host");
 
     // Set up handler for pong to be used while polling.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.15)
 
 include(CMakePrintHelpers)
 
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_C_COMPILER clang-cl)
+set(CMAKE_CXX_COMPILER clang-cl)
 
 project(
   monza_windows

--- a/windows/app-framework/CMakeLists.txt
+++ b/windows/app-framework/CMakeLists.txt
@@ -15,11 +15,11 @@ target_compile_definitions(monza-app-host PRIVATE
 target_include_directories(monza-app-host PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../../app-framework/include/host
 )
-target_compile_definitions(monza-app-host INTERFACE
+target_compile_definitions(monza-app-host PUBLIC
   MONZA_HOST_SUPPORTS_HCS
   CCF_LOGGER_NO_DEPRECATE
 )
-target_include_directories(monza-app-host INTERFACE
+target_include_directories(monza-app-host PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/../../app-framework/include/common
   ${CMAKE_CURRENT_SOURCE_DIR}/../../app-framework/include/host
   ${CCF_REPO_DIR}/include
@@ -27,8 +27,11 @@ target_include_directories(monza-app-host INTERFACE
   ${CCF_REPO_DIR}/3rdparty/exported
 )
 target_compile_options(monza-app-host INTERFACE
-  -include ${CMAKE_CURRENT_SOURCE_DIR}/../include/nix2win.h
+  /FI${CMAKE_CURRENT_SOURCE_DIR}/../include/nix2win.h
 )
-target_link_libraries(monza-app-host INTERFACE
+target_compile_options(monza-app-host PUBLIC
+  /EHs
+)
+target_link_libraries(monza-app-host PUBLIC
   computecore rpcrt4 ntdll
 )

--- a/windows/app-framework/host/hcs_enclave.cc
+++ b/windows/app-framework/host/hcs_enclave.cc
@@ -642,8 +642,7 @@ namespace monza::host
           INFINITE);
       }
       started = false;
-      // Notify the pipe listener that execution finished.
-      finished.store(true);
+      pipe_listener->join();
     }
 
     friend HCSEnclaveAbstract;

--- a/windows/include/nix2win.h
+++ b/windows/include/nix2win.h
@@ -5,7 +5,7 @@
 
 #include <time.h>
 
-struct tm* gmtime_r(const time_t* time, struct tm* result)
+static struct tm* gmtime_r(const time_t* time, struct tm* result)
 {
   if (gmtime_s(result, time) != 0)
   {


### PR DESCRIPTION
- The most recent MSVC update requires clang 14 and the "clang/clang++" aliases force us using the most recent installed MSVC.
- Using "clang-cl" instead seems to detect MSVC 14.33 on the system and uses that even if a newer one is available.
- clang-cl even allows us to select a given toolchain version in the future if we want to.